### PR TITLE
Fixes for AMD checks

### DIFF
--- a/gpuq/csrc/amd.c
+++ b/gpuq/csrc/amd.c
@@ -305,7 +305,7 @@ static int try_load_hipruntime() {
     if (!hip_runtime_dl) {
         hip_runtime_dl = dlopen("libamdhip64.so", RTLD_NOW|RTLD_LOCAL);
         if (!hip_runtime_dl) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             for (int i=0; i<_num_hints; ++i) {
                 strcpy(_hints[i] + _hints_len[i], "libamdhip64.so");
                 hip_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
@@ -313,7 +313,7 @@ static int try_load_hipruntime() {
                 if (hip_runtime_dl)
                     break;
 
-                record_dl_error(&dl_error_buffer, &dl_error_len, true);
+                record_dl_error(&dl_error_buffer, &dl_error_len, TRUE);
             }
         }
 
@@ -324,7 +324,7 @@ static int try_load_hipruntime() {
     if (!device_count_fn) {
         device_count_fn = (hipGetDeviceCount_t)dlsym(hip_runtime_dl, "hipGetDeviceCount");
         if (!device_count_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             return -2;
         }
     }
@@ -332,7 +332,7 @@ static int try_load_hipruntime() {
     if (!device_props_fn) {
         device_props_fn = (hipGetDeviceProperties_t)dlsym(hip_runtime_dl, "hipGetDevicePropertiesR0600");
         if (!device_props_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             return -3;
         }
     }
@@ -340,13 +340,13 @@ static int try_load_hipruntime() {
     if (!error_str_fn) {
         error_str_fn = (hipGetErrorString_t)dlsym(hip_runtime_dl, "hipGetErrorString");
         if (!error_str_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             return -4;
         }
     }
 
     if (dl_error_buffer) {
-        free(dl_error_buffer);
+        free((void*)dl_error_buffer);
         dl_error_buffer = NULL;
         dl_error_len = 0;
     }

--- a/gpuq/csrc/amd.c
+++ b/gpuq/csrc/amd.c
@@ -292,6 +292,8 @@ typedef hipError_t (*hipGetDeviceProperties_t)(hipDeviceProp_t* prop, int device
 typedef hipError_t (*hipGetDeviceCount_t)(int* count);
 typedef const char* (*hipGetErrorString_t)(hipError_t error);
 
+static const char* dl_error_buffer = NULL;
+static size_t dl_error_len = 0;
 
 static void* hip_runtime_dl = NULL;
 static hipGetDeviceCount_t device_count_fn = NULL;
@@ -302,18 +304,16 @@ static hipGetErrorString_t error_str_fn = NULL;
 static int try_load_hipruntime() {
     if (!hip_runtime_dl) {
         hip_runtime_dl = dlopen("libamdhip64.so", RTLD_NOW|RTLD_LOCAL);
-        if (!hip_runtime_dl)
-            return -1;
-
-
-        hip_runtime_dl = dlopen("libamdhip64.so", RTLD_NOW|RTLD_LOCAL);
         if (!hip_runtime_dl) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             for (int i=0; i<_num_hints; ++i) {
                 strcpy(_hints[i] + _hints_len[i], "libamdhip64.so");
                 hip_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
                 _hints[i][_hints_len[i]] = 0;
                 if (hip_runtime_dl)
                     break;
+
+                record_dl_error(&dl_error_buffer, &dl_error_len, true);
             }
         }
 
@@ -323,28 +323,44 @@ static int try_load_hipruntime() {
 
     if (!device_count_fn) {
         device_count_fn = (hipGetDeviceCount_t)dlsym(hip_runtime_dl, "hipGetDeviceCount");
-        if (!device_count_fn)
+        if (!device_count_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             return -2;
+        }
     }
 
     if (!device_props_fn) {
         device_props_fn = (hipGetDeviceProperties_t)dlsym(hip_runtime_dl, "hipGetDevicePropertiesR0600");
-        if (!device_props_fn)
+        if (!device_props_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             return -3;
+        }
     }
 
     if (!error_str_fn) {
         error_str_fn = (hipGetErrorString_t)dlsym(hip_runtime_dl, "hipGetErrorString");
-        if (!error_str_fn)
+        if (!error_str_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             return -4;
+        }
     }
 
+    if (dl_error_buffer) {
+        free(dl_error_buffer);
+        dl_error_buffer = NULL;
+        dl_error_len = 0;
+    }
     return 0;
 }
 
 
 int checkAmd() {
     return try_load_hipruntime();
+}
+
+
+const char* amdGetDlError() {
+    return dl_error_buffer;
 }
 
 

--- a/gpuq/csrc/cuda.c
+++ b/gpuq/csrc/cuda.c
@@ -269,25 +269,25 @@ static int try_load_cudaruntime() {
     if (!cuda_runtime_dl) {
         cuda_runtime_dl = dlopen("libcudart.so", RTLD_NOW|RTLD_LOCAL);
         if (!cuda_runtime_dl) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             cuda_runtime_dl = dlopen("libcudart.so.12", RTLD_NOW|RTLD_LOCAL);
         }
 
         if (!cuda_runtime_dl) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, true);
+            record_dl_error(&dl_error_buffer, &dl_error_len, TRUE);
             for (int i=0; i<_num_hints; ++i) {
                 strcpy(_hints[i] + _hints_len[i], "libcudart.so");
                 cuda_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
                 _hints[i][_hints_len[i]] = 0;
                 if (cuda_runtime_dl)
                     break;
-                record_dl_error(&dl_error_buffer, &dl_error_len, true);
+                record_dl_error(&dl_error_buffer, &dl_error_len, TRUE);
                 strcpy(_hints[i] + _hints_len[i], "libcudart.so.12");
                 cuda_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
                 _hints[i][_hints_len[i]] = 0;
                 if (cuda_runtime_dl)
                     break;
-                record_dl_error(&dl_error_buffer, &dl_error_len, true);
+                record_dl_error(&dl_error_buffer, &dl_error_len, TRUE);
             }
         }
 
@@ -298,7 +298,7 @@ static int try_load_cudaruntime() {
     if (!device_count_fn) {
         device_count_fn = (cudaGetDeviceCount_t)dlsym(cuda_runtime_dl, "cudaGetDeviceCount");
         if (!device_count_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             return -2;
         }
     }
@@ -306,10 +306,10 @@ static int try_load_cudaruntime() {
     if (!device_props_fn) {
         device_props_fn = (cudaGetDeviceProperties_t)dlsym(cuda_runtime_dl, "cudaGetDeviceProperties_v2");
         if (!device_props_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             device_props_fn = (cudaGetDeviceProperties_t)dlsym(cuda_runtime_dl, "cudaGetDeviceProperties");
             if (!device_props_fn) {
-                record_dl_error(&dl_error_buffer, &dl_error_len, true);
+                record_dl_error(&dl_error_buffer, &dl_error_len, TRUE);
                 return -3;
             }
         }
@@ -318,13 +318,13 @@ static int try_load_cudaruntime() {
     if (!error_str_fn) {
         error_str_fn = (cudaGetErrorString_t)dlsym(cuda_runtime_dl, "cudaGetErrorString");
         if (!error_str_fn) {
-            record_dl_error(&dl_error_buffer, &dl_error_len, false);
+            record_dl_error(&dl_error_buffer, &dl_error_len, FALSE);
             return -4;
         }
     }
 
     if (dl_error_buffer) {
-        free(dl_error_buffer);
+        free((void*)dl_error_buffer);
         dl_error_buffer = NULL;
         dl_error_len = 0;
     }

--- a/gpuq/csrc/cuda.c
+++ b/gpuq/csrc/cuda.c
@@ -256,6 +256,8 @@ typedef cudaError_t (*cudaGetDeviceProperties_t)(struct cudaDeviceProp* prop, in
 typedef cudaError_t (*cudaGetDeviceCount_t)(int* count);
 typedef const char* (*cudaGetErrorString_t)(cudaError_t error);
 
+static const char* dl_error_buffer = NULL;
+static size_t dl_error_len = 0;
 
 static void* cuda_runtime_dl = NULL;
 static cudaGetDeviceCount_t device_count_fn = NULL;
@@ -266,21 +268,26 @@ static cudaGetErrorString_t error_str_fn = NULL;
 static int try_load_cudaruntime() {
     if (!cuda_runtime_dl) {
         cuda_runtime_dl = dlopen("libcudart.so", RTLD_NOW|RTLD_LOCAL);
-        if (!cuda_runtime_dl)
+        if (!cuda_runtime_dl) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             cuda_runtime_dl = dlopen("libcudart.so.12", RTLD_NOW|RTLD_LOCAL);
+        }
 
         if (!cuda_runtime_dl) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, true);
             for (int i=0; i<_num_hints; ++i) {
                 strcpy(_hints[i] + _hints_len[i], "libcudart.so");
                 cuda_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
                 _hints[i][_hints_len[i]] = 0;
                 if (cuda_runtime_dl)
                     break;
+                record_dl_error(&dl_error_buffer, &dl_error_len, true);
                 strcpy(_hints[i] + _hints_len[i], "libcudart.so.12");
                 cuda_runtime_dl = dlopen(_hints[i], RTLD_NOW|RTLD_LOCAL);
                 _hints[i][_hints_len[i]] = 0;
                 if (cuda_runtime_dl)
                     break;
+                record_dl_error(&dl_error_buffer, &dl_error_len, true);
             }
         }
 
@@ -290,31 +297,48 @@ static int try_load_cudaruntime() {
 
     if (!device_count_fn) {
         device_count_fn = (cudaGetDeviceCount_t)dlsym(cuda_runtime_dl, "cudaGetDeviceCount");
-        if (!device_count_fn)
+        if (!device_count_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             return -2;
+        }
     }
 
     if (!device_props_fn) {
         device_props_fn = (cudaGetDeviceProperties_t)dlsym(cuda_runtime_dl, "cudaGetDeviceProperties_v2");
         if (!device_props_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             device_props_fn = (cudaGetDeviceProperties_t)dlsym(cuda_runtime_dl, "cudaGetDeviceProperties");
-            if (!device_props_fn)
+            if (!device_props_fn) {
+                record_dl_error(&dl_error_buffer, &dl_error_len, true);
                 return -3;
+            }
         }
     }
 
     if (!error_str_fn) {
         error_str_fn = (cudaGetErrorString_t)dlsym(cuda_runtime_dl, "cudaGetErrorString");
-        if (!error_str_fn)
+        if (!error_str_fn) {
+            record_dl_error(&dl_error_buffer, &dl_error_len, false);
             return -4;
+        }
     }
 
+    if (dl_error_buffer) {
+        free(dl_error_buffer);
+        dl_error_buffer = NULL;
+        dl_error_len = 0;
+    }
     return 0;
 }
 
 
 int checkCuda() {
     return try_load_cudaruntime();
+}
+
+
+const char* cudaGetDlError() {
+    return dl_error_buffer;
 }
 
 

--- a/gpuq/csrc/gpuq.c
+++ b/gpuq/csrc/gpuq.c
@@ -1,5 +1,6 @@
 #include "types.h"
 #include <stddef.h>
+#include <dlfcn.h>
 
 #include "patchlevel.h"
 
@@ -94,11 +95,14 @@ gpuq_checkcuda(PyObject* self, PyObject* args) {
              cudaDevices = 0;
     }
 
+    const char* error_str = NULL;
+
     switch (status) {
     case 0:
         Py_RETURN_NONE;
     case -1:
-        return PyUnicode_InternFromString("Could not load libcudart.so");
+        error_str = cudaGetDlError();
+        return PyUnicode_FromFormat("%s: %s", "Could not load libcudart.so", (error_str ? error_str : "(unknown)"));
     case -2:
         return PyUnicode_InternFromString("Could not resolve cudaGetDeviceCount");
     case -3:
@@ -109,25 +113,27 @@ gpuq_checkcuda(PyObject* self, PyObject* args) {
         return PyUnicode_InternFromString(cudaGetErrStr(status));
     }
 
-
     Py_RETURN_NONE;
 }
 
 
 static PyObject*
 gpuq_checkamd(PyObject* self, PyObject* args) {
-    int status = checkCuda();
+    int status = checkAmd();
     if (!status) {
         status = amdGetDeviceCount(&amdDevices);
         if (status)
              amdDevices = 0;
     }
 
+    const char* error_str = NULL;
+
     switch (status) {
     case 0:
         Py_RETURN_NONE;
     case -1:
-        return PyUnicode_InternFromString("Could not load libamdhip64.so");
+        error_str = amdGetDlError();
+        return PyUnicode_FromFormat("%s: %s", "Could not load libamdhip64.so", (error_str ? error_str : "(unknown)"));
     case -2:
         return PyUnicode_InternFromString("Could not resolve hipGetDeviceCount");
     case -3:
@@ -137,7 +143,6 @@ gpuq_checkamd(PyObject* self, PyObject* args) {
     default:
         return PyUnicode_InternFromString(amdGetErrStr(status));
     }
-
 
     Py_RETURN_NONE;
 }

--- a/gpuq/csrc/gpuq.c
+++ b/gpuq/csrc/gpuq.c
@@ -102,7 +102,7 @@ gpuq_checkcuda(PyObject* self, PyObject* args) {
         Py_RETURN_NONE;
     case -1:
         error_str = cudaGetDlError();
-        return PyUnicode_FromFormat("%s: %s", "Could not load libcudart.so", (error_str ? error_str : "(unknown)"));
+        return PyUnicode_FromFormat("%s:\n%s", "Could not load libcudart.so", (error_str ? error_str : "(unknown)"));
     case -2:
         return PyUnicode_InternFromString("Could not resolve cudaGetDeviceCount");
     case -3:
@@ -133,7 +133,7 @@ gpuq_checkamd(PyObject* self, PyObject* args) {
         Py_RETURN_NONE;
     case -1:
         error_str = amdGetDlError();
-        return PyUnicode_FromFormat("%s: %s", "Could not load libamdhip64.so", (error_str ? error_str : "(unknown)"));
+        return PyUnicode_FromFormat("%s:\n%s", "Could not load libamdhip64.so", (error_str ? error_str : "(unknown)"));
     case -2:
         return PyUnicode_InternFromString("Could not resolve hipGetDeviceCount");
     case -3:

--- a/gpuq/csrc/types.h
+++ b/gpuq/csrc/types.h
@@ -5,6 +5,15 @@
 #include <Python.h>
 
 
+#ifndef FALSE
+#define FALSE (0)
+#endif
+
+#ifndef TRUE
+#define TRUE (1)
+#endif
+
+
 #define MAX_HINTS 32
 #define MAX_HINT_LEN 127
 #define HIN_OVEARHEAD 32

--- a/gpuq/csrc/types.h
+++ b/gpuq/csrc/types.h
@@ -45,6 +45,7 @@ typedef struct {
 
 
 int checkCuda();
+const char* cudaGetDlError();
 const char* cudaGetErrStr(int status);
 int cudaGetDeviceCount(int* count);
 int cudaGetDeviceProps(int index, GpuProp* obj);
@@ -52,10 +53,15 @@ void cudaClean();
 
 
 int checkAmd();
+const char* amdGetDlError();
 const char* amdGetErrStr(int status);
 int amdGetDeviceCount(int* count);
 int amdGetDeviceProps(int index, GpuProp* obj);
 void amdClean();
+
+
+// utils
+void record_dl_error(const char** dl_error_buffer, size_t* dl_error_len, int append);
 
 
 static inline void bytes_to_hex(const char* in, char* out, int bytes_len) {

--- a/gpuq/csrc/utils.c
+++ b/gpuq/csrc/utils.c
@@ -1,0 +1,46 @@
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+
+void record_dl_error(const char** dl_error_buffer, size_t* dl_error_len, int append) {
+    const char* err = dlerror();
+    if (!err) {
+        if (append)
+            return;
+
+        if (dl_error_buffer) {
+            free((void*)dl_error_buffer);
+            dl_error_buffer = NULL;
+            dl_error_len = 0;
+        }
+
+        return;
+    }
+
+    size_t err_len = strlen(err);
+
+    if (!append && dl_error_buffer) {
+        free((void*)dl_error_buffer);
+        dl_error_buffer = NULL;
+        dl_error_len = 0;
+    }
+
+    size_t new_len = err_len + 3;
+    if (dl_error_len)
+        new_len += (*dl_error_len) + 1;
+
+    char* new_buffer = (char*)malloc(new_len);
+    if (dl_error_buffer) {
+        strncpy(new_buffer, *dl_error_buffer, *dl_error_len);
+        new_buffer[*dl_error_len] = '\n';
+        *dl_error_buffer = new_buffer;
+        new_buffer += (*dl_error_len) + 1;
+    } else {
+        *dl_error_buffer = new_buffer;
+    }
+    strncpy(new_buffer, " * ", 3);
+    strncpy(new_buffer + 3, err, err_len);
+    *dl_error_len = new_len;
+}

--- a/gpuq/csrc/utils.c
+++ b/gpuq/csrc/utils.c
@@ -33,15 +33,15 @@ void record_dl_error(const char** dl_error_buffer, size_t* dl_error_len, int app
 
     char* new_buffer = (char*)malloc(new_len + 1); // +1 for the null-terminator
     if (*dl_error_buffer) {
-        strncpy(new_buffer, *dl_error_buffer, *dl_error_len);
+        memcpy(new_buffer, *dl_error_buffer, *dl_error_len);
         new_buffer[*dl_error_len] = '\n';
         (*dl_error_buffer) = new_buffer;
         new_buffer += (*dl_error_len) + 1;
     } else {
         (*dl_error_buffer) = new_buffer;
     }
-    strncpy(new_buffer, " * ", 3);
-    strncpy(new_buffer + 3, err, err_len);
+    memcpy(new_buffer, " * ", 3);
+    memcpy(new_buffer + 3, err, err_len);
     new_buffer[err_len + 3] = '\0';
     (*dl_error_len) = new_len;
 }

--- a/gpuq/csrc/utils.c
+++ b/gpuq/csrc/utils.c
@@ -10,10 +10,10 @@ void record_dl_error(const char** dl_error_buffer, size_t* dl_error_len, int app
         if (append)
             return;
 
-        if (dl_error_buffer) {
-            free((void*)dl_error_buffer);
-            dl_error_buffer = NULL;
-            dl_error_len = 0;
+        if (*dl_error_buffer) {
+            free((void*)(*dl_error_buffer));
+            (*dl_error_buffer) = NULL;
+            (*dl_error_len) = 0;
         }
 
         return;
@@ -21,26 +21,27 @@ void record_dl_error(const char** dl_error_buffer, size_t* dl_error_len, int app
 
     size_t err_len = strlen(err);
 
-    if (!append && dl_error_buffer) {
-        free((void*)dl_error_buffer);
-        dl_error_buffer = NULL;
-        dl_error_len = 0;
+    if (!append && (*dl_error_buffer)) {
+        free((void*)(*dl_error_buffer));
+        (*dl_error_buffer) = NULL;
+        (*dl_error_len) = 0;
     }
 
     size_t new_len = err_len + 3;
-    if (dl_error_len)
+    if (*dl_error_len)
         new_len += (*dl_error_len) + 1;
 
-    char* new_buffer = (char*)malloc(new_len);
-    if (dl_error_buffer) {
+    char* new_buffer = (char*)malloc(new_len + 1); // +1 for the null-terminator
+    if (*dl_error_buffer) {
         strncpy(new_buffer, *dl_error_buffer, *dl_error_len);
         new_buffer[*dl_error_len] = '\n';
-        *dl_error_buffer = new_buffer;
+        (*dl_error_buffer) = new_buffer;
         new_buffer += (*dl_error_len) + 1;
     } else {
-        *dl_error_buffer = new_buffer;
+        (*dl_error_buffer) = new_buffer;
     }
     strncpy(new_buffer, " * ", 3);
     strncpy(new_buffer + 3, err, err_len);
-    *dl_error_len = new_len;
+    new_buffer[err_len + 3] = '\0';
+    (*dl_error_len) = new_len;
 }

--- a/gpuq/version.py
+++ b/gpuq/version.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 
-version: str = "1.4.2"
+version: str = "1.5.0"
 repo: str = "unknown"
 commit: str = "unknown"
 has_repo: bool = False

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,6 @@ setup(name=package_name,
         'build_py': custom_wheel
     },
     ext_modules=[
-        Extension("gpuq.C", ["gpuq/csrc/gpuq.c", "gpuq/csrc/amd.c", "gpuq/csrc/cuda.c", "gpuq/csrc/utils.c"], extra_compile_args=['-O3'])
+        Extension("gpuq.C", ["gpuq/csrc/gpuq.c", "gpuq/csrc/amd.c", "gpuq/csrc/cuda.c", "gpuq/csrc/utils.c"], extra_compile_args=['-O3', '-Werror'])
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,6 @@ setup(name=package_name,
         'build_py': custom_wheel
     },
     ext_modules=[
-        Extension("gpuq.C", ["gpuq/csrc/gpuq.c", "gpuq/csrc/amd.c", "gpuq/csrc/cuda.c"], extra_compile_args=['-O3'])
+        Extension("gpuq.C", ["gpuq/csrc/gpuq.c", "gpuq/csrc/amd.c", "gpuq/csrc/cuda.c", "gpuq/csrc/utils.c"], extra_compile_args=['-O3'])
     ],
 )


### PR DESCRIPTION
amdcheck has been calling cudaCheck due to a typing error... The PR fixes that, and adds more detailed diagnostics for any dl-related errors.